### PR TITLE
Update threetenbp to v1.3.4 and use ZoneRulesInitializer for on-demand initialization

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,8 +24,8 @@ ext {
 }
 
 ext.deps = [
-        threetenbp : "org.threeten:threetenbp:1.3.3",
-        threetenbp_notzdb : "org.threeten:threetenbp:1.3.3:no-tzdb",
+        threetenbp : "org.threeten:threetenbp:1.3.4",
+        threetenbp_notzdb : "org.threeten:threetenbp:1.3.4:no-tzdb",
         javapoet : "com.squareup:javapoet:1.8.0",
         google_options: "com.github.pcj:google-options:1.0.0",
 

--- a/runtime/src/main/java/com/gabrielittner/threetenbp/LazyThreeTen.java
+++ b/runtime/src/main/java/com/gabrielittner/threetenbp/LazyThreeTen.java
@@ -1,8 +1,11 @@
 package com.gabrielittner.threetenbp;
 
+import android.app.Application;
 import android.content.Context;
-import org.threeten.bp.ZoneId;
+
+import org.threeten.bp.zone.ZoneRulesInitializer;
 import org.threeten.bp.zone.ZoneRulesProvider;
+
 import java.util.concurrent.atomic.AtomicBoolean;
 
 public final class LazyThreeTen {
@@ -12,7 +15,8 @@ public final class LazyThreeTen {
         if (INITIALIZED.getAndSet(true)) {
             return;
         }
-        ZoneRulesProvider.registerProvider(new LazyZoneRulesProvider(context));
+        ZoneRulesInitializer.setInitializer(
+                new LazyZoneRulesInitializer((Application) context.getApplicationContext()));
     }
 
     /**

--- a/runtime/src/main/java/com/gabrielittner/threetenbp/LazyZoneRulesInitializer.java
+++ b/runtime/src/main/java/com/gabrielittner/threetenbp/LazyZoneRulesInitializer.java
@@ -1,0 +1,20 @@
+package com.gabrielittner.threetenbp;
+
+import android.app.Application;
+
+import org.threeten.bp.zone.ZoneRulesInitializer;
+import org.threeten.bp.zone.ZoneRulesProvider;
+
+public class LazyZoneRulesInitializer extends ZoneRulesInitializer {
+
+    private final Application application;
+
+    public LazyZoneRulesInitializer(final Application application) {
+        this.application = application;
+    }
+
+    @Override
+    protected void initializeProviders() {
+        ZoneRulesProvider.registerProvider(new LazyZoneRulesProvider(application));
+    }
+}


### PR DESCRIPTION
With this change, almost nothing will need to happen at application startup - the initializer (along with the application context) will be registered, but any other library code execution will be deferred until ZoneRulesProvider is initialized when ThreeTenBP first needs to make use of time zone data later on in execution. Most notably, this prevents ServiceLoader from being used to try to load time zone data, as that was a big performance hit within ThreeTenBP before on Android devices.